### PR TITLE
Larger the gap to avoid wrong merge

### DIFF
--- a/src/vlan.c
+++ b/src/vlan.c
@@ -62,7 +62,7 @@ vlan_offset(struct vlan_arr *arr, uint16_t metaidx)
 static inline uint16_t
 vlan_start_vid(struct vlan_arr *arr, uint16_t metaidx)
 {
-	return (metaidx < arr->nummeta) ? arr->meta[metaidx].start * 16 : 4096;
+	return (metaidx < arr->nummeta) ? arr->meta[metaidx].start * 16 : (VLAN_MAX + 32);
 }
 
 static inline uint16_t
@@ -232,6 +232,7 @@ int
 vlan_set(struct vlan_arr *arr, uint16_t vid)
 {
 	eprintf(DEBUG_GENERAL, "%s(%p) set %hu", arr->name, arr, vid);
+	assert(vid < VLAN_MAX);
 
 	uint16_t metaidx = vlan_find_or_add_room(arr, vid);
 	assert(vid >= vlan_start_vid(arr, metaidx));
@@ -285,6 +286,8 @@ int
 vlan_unset(struct vlan_arr *arr, uint16_t vid)
 {
 	eprintf(DEBUG_GENERAL, "%s(%p) unset %hu", arr->name, arr, vid);
+	assert(vid < VLAN_MAX);
+
 	uint16_t metaidx;
 
 	if (vlan_find(arr, vid, &metaidx) == 0)

--- a/src/vlan.h
+++ b/src/vlan.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#define VLAN_MAX 4096
+
 struct vlan_arr;
 
 int vlan_set(struct vlan_arr *arr, uint16_t vid); // returns old mask

--- a/src/vlan.h
+++ b/src/vlan.h
@@ -24,8 +24,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#define VLAN_MAX 4096
-
 struct vlan_arr;
 
 int vlan_set(struct vlan_arr *arr, uint16_t vid); // returns old mask


### PR DESCRIPTION
Two changes for "vlan_set()/vlan_unset()":                                       
                                                                                 
- Larger the gap to avoid wrong merge                                            
                                                                                                                                        
  With "vlan_set(4095)", it will be wrongly merged with the last                 
  one: [4096, 4096].  So, larger the gap ( MUST be >= 32 )                       
  to avoid this wrong behavior.                                                  
                                                                                 
- Limit the vlan id range                                                        
                                                                                 
  The vlan id range should be limited to (0, 4096).                              
                                                                                    